### PR TITLE
Fix IndexOutOfRangeException for some invalid user input.

### DIFF
--- a/EmailValidation/EmailValidator.cs
+++ b/EmailValidation/EmailValidator.cs
@@ -260,13 +260,13 @@ namespace EmailValidation
 			if (email.Length == 0)
 				return false;
 
-			if (!SkipWord (email, ref index, allowInternational) || index >= email.Length)
+			if (index >= email.Length || !SkipWord (email, ref index, allowInternational))
 				return false;
 
 			while (index < email.Length && email[index] == '.') {
 				index++;
 
-				if (!SkipWord (email, ref index, allowInternational) || index >= email.Length)
+				if (index >= email.Length || !SkipWord (email, ref index, allowInternational))
 					return false;
 			}
 

--- a/UnitTests/Test.cs
+++ b/UnitTests/Test.cs
@@ -80,7 +80,11 @@ namespace UnitTests
 			"a\"b(c)d,e:f;g<h>i[j\\k]l@example.com",
 			"just\"not\"right@example.com",
 			"this is\"not\\allowed@example.com",
-			"this\\ still\\\"not\\\\allowed@example.com"
+			"this\\ still\\\"not\\\\allowed@example.com",
+
+			// example of real (invalid) input from real users. This
+			// specifically used to cause an IndexOutOfRangeException.
+			"Moved."
 		};
 
 		static readonly string[] ValidInternationalAddresses = {

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -29,10 +29,11 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="nunit.framework">
-      <Private>False</Private>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Test.cs" />
@@ -43,5 +44,11 @@
       <Project>{B03674D1-65A4-4A79-AAD1-0EA9781A3ED7}</Project>
       <Name>EmailValidation</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
Sadly user's do stupid things sometimes, like keying text strings into email fields. I have several real world examples of users having keyed "Moved." or "Does not want email." etc. into an email address field. The previous code would crash with an IndexOutOfRangeException if the input string provided ended with a . character. This fixes that.

Also added nunit as a nuget package and enabled package restore, so people cloning the repository can just build it and have it work.