### PR TITLE
Adds a validation attribute.

### DIFF
--- a/EmailValidation/EmailAttribute.cs
+++ b/EmailValidation/EmailAttribute.cs
@@ -1,0 +1,63 @@
+﻿//
+// EmailValidator.cs
+//
+// Author: Michel Feinstein <michel@feinstein.com.br>
+//
+// Copyright (c) 2013-2016 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace EmailValidation
+{
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+	public sealed class EmailAttribute : ValidationAttribute
+	{
+		public EmailAttribute(bool allowTopLevelDomains = false, bool allowInternational = false)
+		{
+			AllowTopLevelDomains = allowTopLevelDomains;
+			AllowInternational = allowInternational;
+		}
+
+		public bool AllowTopLevelDomains { get; set; }
+
+		public bool AllowInternational { get; set; }
+
+		protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+		{
+			string[] memberNames = new string[] { validationContext.MemberName };
+
+			if (value == null)
+			{
+				return new ValidationResult("Email can't be null", memberNames);
+			}
+
+			if (EmailValidator.Validate((string)value, AllowTopLevelDomains, AllowInternational))
+			{
+				return ValidationResult.Success;
+			}
+			else
+			{
+				return new ValidationResult("Email invalid", memberNames);
+			}
+		}
+	}
+}

--- a/EmailValidation/EmailValidation.csproj
+++ b/EmailValidation/EmailValidation.csproj
@@ -33,8 +33,18 @@
     <DocumentationFile>bin\Release\EmailValidation.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="EmailAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="EmailValidator.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Portable.DataAnnotations, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Portable.DataAnnotations.1.0.0\lib\portable-net40+netcore45+sl5+wp8+wpa81\Portable.DataAnnotations.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/EmailValidation/packages.config
+++ b/EmailValidation/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Portable.DataAnnotations" version="1.0.0" targetFramework="portable40-net40+sl5+win8+wp8" />
+</packages>

--- a/UnitTests/Test.cs
+++ b/UnitTests/Test.cs
@@ -26,6 +26,8 @@
 using System;
 using NUnit.Framework;
 using EmailValidation;
+using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
 
 namespace UnitTests
 {
@@ -166,6 +168,68 @@ namespace UnitTests
 		{
 			for (int i = 0; i < ValidInternationalAddresses.Length; i++)
 				Assert.IsTrue (EmailValidator.Validate (ValidInternationalAddresses[i], true, true), "Valid International Address #{0}", i);
+		}
+
+		[Test]
+		public void TestThrowsExceptionIfNull()
+		{
+			Assert.Throws<ArgumentNullException>(() => EmailValidator.Validate(null, true, true), "Null Address");
+		}
+
+		[Test]
+		public void TestValidationAttributeValidAddresses()
+		{
+			EmailValidationTarget target = new EmailValidationTarget();
+
+			foreach (var email in ValidAddresses)
+			{
+				target.Email = email;
+				Assert.IsTrue(AreAttributesValid(target), "Valid Address {0}", email);
+			}
+		}
+
+		[Test]
+		public void TestValidationAttributeInvalidAddresses()
+		{
+			EmailValidationTarget target = new EmailValidationTarget();
+
+			foreach (var email in InvalidAddresses)
+			{
+				target.Email = email;
+				Assert.IsFalse(AreAttributesValid(target), "Invalid Address {0}", email);
+			}
+		}
+
+		[Test]
+		public void TestValidationAttributeValidInternationalAddresses()
+		{
+			var target = new InternationalEmailValidationTarget();
+
+			foreach (var email in ValidInternationalAddresses)
+			{
+				target.Email = email;
+				Assert.IsTrue(AreAttributesValid(target), "Valid International Address {0}", email);
+			}
+		}
+
+		private bool AreAttributesValid(object target)
+		{
+			var context = new ValidationContext(target, null, null);
+			var results = new List<ValidationResult>();
+
+			return Validator.TryValidateObject(target, context, results, true);
+		}
+
+		private class EmailValidationTarget
+		{
+			[Email(true)]
+			public string Email { get; set; }
+		}
+
+		private class InternationalEmailValidationTarget
+		{
+			[Email(true, true)]
+			public string Email { get; set; }
 		}
 	}
 }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -29,10 +29,15 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Portable.DataAnnotations, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Portable.DataAnnotations.1.0.0\lib\net40\Portable.DataAnnotations.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Test.cs" />
@@ -46,5 +51,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="Portable.DataAnnotations" version="1.0.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Wraps the EmailValidator in a ValidationAttribute so Properties can be easily validated.
In order to implement the validations on a PCL project the "Bait and Switch"  trick was used.

Added a test for `null` strings as well.

Closes issue #10.